### PR TITLE
allow remote connections

### DIFF
--- a/src/Connection.js
+++ b/src/Connection.js
@@ -11,12 +11,15 @@ class Connection {
     constructor(props) {
         props = props || {};
         this.props = props;
-        this.props.port = this.props.port || 8081;
+        
         this.autoSubscribes = this.props.autoSubscribes || [];
         this.autoSubscribeLog = this.props.autoSubscribeLog;
 
-        this.socket = window.io.connect(
-            window.location.protocol + '//' + window.location.host.replace('3000', this.props.port), // todo: do replace only if not in iFrame
+        this.props.protocol = this.props.protocol || window.location.protocol;
+        this.props.host = this.props.host || window.location.host && window.location.host.substr(0, window.location.host.indexOf(':'));
+        this.props.port = this.props.port || 8081;
+        
+        this.socket = window.io.connect(this.props.protocol.replace(':', '') + '://' + this.props.host + ':' + this.props.port,
             {query: 'ws=true'});
         this.states = {};
         this.objects = null;

--- a/src/GenericApp.js
+++ b/src/GenericApp.js
@@ -67,6 +67,7 @@ class GenericApp extends Router {
         this.encryptedFields = props.encryptedFields || (settings && settings.encryptedFields) || [];
 
         this.socket = new Connection({
+            ...props && props.socket,
             onProgress: progress => {
                 if (progress === PROGRESS.CONNECTING) {
                     this.setState({connected: false});


### PR DESCRIPTION
This pr allows remote connection to ioBroker socket by specifying the necessary data in the `App.js`:
```
constructor(props) {
    const extendedProps = {...props};
    extendedProps.socket = {
	protocol: 'https',
	host: '192.168.178.29',
	port: 8082
    }
    super(extendedProps);
}

```