### PR TITLE
Fixed and improved JSdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@types/iobroker": "^3.2.3",
+    "@types/react": "^16.9.52",
     "babel": "^6.23.0",
     "react-dropzone": "^11.2.0",
     "del": "^6.0.0",

--- a/src/Components/Router.js
+++ b/src/Components/Router.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import {Component} from 'react';
 
 /**
  * @template P Type of the properties object.

--- a/src/Components/Router.js
+++ b/src/Components/Router.js
@@ -1,11 +1,13 @@
 import React, {Component} from 'react';
 
 /**
- * @extends {Component<{}>}
+ * @template P Type of the properties object.
+ * @template S Type of the internal state object.
+ * @extends {Component<P, S>}
  */
 class Router extends Component {
     /**
-     * @param {{}} props The React properties of this component.
+     * @param {P} props The React properties of this component.
      */
     constructor(props) {
         super(props);

--- a/src/Components/Utils.js
+++ b/src/Components/Utils.js
@@ -987,7 +987,7 @@ class Utils {
     /**
      * Get the current theme name (either from local storage or the browser settings).
      * @param {string} [themeName]
-     * @returns {string | null}
+     * @returns {string}
      */
     static getThemeName(themeName = '') {
         return themeName ? themeName : window.localStorage && window.localStorage.getItem('App.themeName') ?

--- a/src/Components/types.d.ts
+++ b/src/Components/types.d.ts
@@ -111,7 +111,7 @@ export interface ObjectBrowserProps {
     /** Custom object editor React component to use */
     objectBrowserEditObject?: any;
     /** Router */
-    router?: Router;
+    router?: Router<{}, {}>;
     /** Object types to show */
     types?: ObjectBrowserType[];
     /** Columns to display */

--- a/src/GenericApp.js
+++ b/src/GenericApp.js
@@ -33,6 +33,9 @@ const styles = {
 };
 
 
+/**
+ * @extends {Router<import('./types').GenericAppProps, import('./types').GenericAppState>}
+ */
 class GenericApp extends Router {
     /**
      * @param {import('./types').GenericAppProps} props

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -58,6 +58,23 @@ export interface GenericAppSettings extends GenericAppProps {
     doNotLoadAllObjects?: boolean;
 }
 
+export interface GenericAppState {
+    selectedTab: string;
+    selectedTabNum: number;
+    native: {};
+    errorText: string;
+    changed: boolean;
+    connected: boolean;
+    loaded: boolean;
+    isConfigurationError: string;
+    toast: string;
+    theme: Theme;
+    themeName: string;
+    themeType: string;
+    bottomButtons: boolean;
+    width: Width;
+}
+
 export type Width = ('xs' | 'sm' | 'md' | 'lg' | 'xl');
 
 export interface Theme extends MuiTheme {


### PR DESCRIPTION
These are some fixes to the type definitions that we have added in the last PR.

- Made Router generic
- Fixed getThemeName() (always returns a string)
- Fixed Router not extending React.Component<>