### PR TITLE
Allow GenericApp.showError() to take a JSX.Element as argument to support more complex error dialogs

### DIFF
--- a/src/Dialogs/Error.js
+++ b/src/Dialogs/Error.js
@@ -31,7 +31,7 @@ const styles = theme => ({
  * @typedef {object} DialogErrorProps
  * @property {string} [key] The key to identify this component.
  * @property {string} [title] The dialog title; default: Error (translated)
- * @property {string} text The dialog text.
+ * @property {string | JSX.Element} text The dialog text.
  * @property {() => void} [onClose] Close handler.
  * @property {{titleBackground: string; titleColor: string}} classes The styling class names.
  *
@@ -71,7 +71,10 @@ DialogError.propTypes = {
     key: PropTypes.string,
     onClose: PropTypes.func,
     title: PropTypes.string,
-    text: PropTypes.string,
+    text: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element
+    ]),
     icon: PropTypes.object
 };
 

--- a/src/GenericApp.js
+++ b/src/GenericApp.js
@@ -635,7 +635,7 @@ class GenericApp extends Router {
 
     /**
      * Set the error text to be shown.
-     * @param {string} text
+     * @param {string | JSX.Element} text
      */
     showError(text) {
         this.setState({errorText: text});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -64,7 +64,7 @@ export interface GenericAppState {
     selectedTab: string;
     selectedTabNum: number;
     native: ioBroker.AdapterConfig;
-    errorText: string;
+    errorText: string | JSX.Element;
     changed: boolean;
     connected: boolean;
     loaded: boolean;


### PR DESCRIPTION
This will only change the type definitions of the `errorText` state and the `showError(...)` method of `GenericApp` and the type definition of the `text` property for the `DialogError`.

In this way, more complex error dialogs can be created by using react elements as error text.

Usage example:
https://github.com/crycode-de/ioBroker.canbus/blob/master/admin/src/components/import-export.tsx#L672
![grafik](https://user-images.githubusercontent.com/24603271/114374717-3b6e3a00-9b84-11eb-89cd-8b19a93e9352.png)

