### PR TITLE
Dependencies of produced npm package now contain all required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ If you want to create the configuration page with react:
     "react-dom": "^16.13.1",
     "react-icons": "^3.10.0",
     "react-scripts": "^3.4.4",
-    "@sentry/browser": "^5.29.2",
-    "@material-ui/core": "^4.11.2",
     "@iobroker/adapter-react": "^1.5.6",
     "del": "^6.0.0",
     "gulp": "^4.0.2"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,7 @@ gulp.task('copy', () => Promise.all([
         const package_ = require('./package.json');
         const packageSrc = require('./src/package.json');
         packageSrc.version = package_.version;
+        packageSrc.dependencies = package_.dependencies;
         !fs.existsSync(`${__dirname}/dist`) && fs.mkdirSync(`${__dirname}/dist`);
         fs.writeFileSync(`${__dirname}/dist/package.json`, JSON.stringify(packageSrc, null, 2));
         resolve();


### PR DESCRIPTION
(except for core React modules)

Tested with the current create-adapter version.

This will fix #17 