### PR TITLE
Add @material-ui/icons dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@sentry/browser": "^6.3.6",
     "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "react-color": "^2.19.3",
     "react-colorful": "^5.1.4",
     "react-dropzone": "^11.3.2",


### PR DESCRIPTION
In #20 we forgot to add `@material-ui/icons` as a dependency. This is fixed with this PR.

See also the bug report in #22.