### PR TITLE
fix: include transform-runtime babel plugin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,10 @@ gulp.task('typedefs', () => {
 
 const babelOptions = {
     presets: ['@babel/preset-env', '@babel/preset-react'],
-    plugins: ['@babel/plugin-proposal-class-properties']
+    plugins: [
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-transform-runtime'
+    ]
 };
 
 gulp.task('compile', gulp.parallel('copy',
@@ -76,7 +79,8 @@ gulp.task('compile', gulp.parallel('copy',
             .pipe(babel({
                 presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-flow'],
                 plugins: [
-                    '@babel/plugin-proposal-class-properties'
+                    '@babel/plugin-proposal-class-properties',
+                    '@babel/plugin-transform-runtime'
                 ]
             }))
             .pipe(sourcemaps.write('.'))

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@alcalzone/release-script-plugin-license": "^3.5.0",
     "@babel/core": "^7.16.12",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-flow": "^7.16.7",
     "@babel/preset-react": "^7.16.7",


### PR DESCRIPTION
This change makes it possible to consume this library in other projects without `babel`. Without the change, it fails at runtime with this nice error:
![grafik](https://user-images.githubusercontent.com/17641229/157034088-907d1177-e307-4fd8-8f8d-fde7867bcdd0.png)
